### PR TITLE
[WIP]update readme 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Things you may want to cover:
 ## Association
 - has_many :messages 
 - has_many :groups, through:users_groups
-
+- has_many:users_groups
 
 
 ## groupsテーブル
@@ -56,6 +56,8 @@ Things you may want to cover:
 
 ## Association
 - has_many :users, through:users_groups
+- has_many :users_groups
+- has_many :messages
 
 ## messagesテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|integer|null: false, foreign_key: true|
-|e-mail|integer|null: false, foreign_key: true|
-|password|integer|null: false, foreign_key: true|
+|name|integer|null: false|
+|e-mail|integer|null: false|
+|password|integer|null: false|
 | add_index :users,  :name|
 
 ## Association
@@ -52,7 +52,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group-name|integer|null: false, foreign_key: true|
+|name|integer|null: false|
 
 ## Association
 - has_many :users, through:users_groups
@@ -62,11 +62,10 @@ Things you may want to cover:
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false, foreign_key: true|
-|image|string|null: true, foreign_key: true|
+|body|text||
+|image|string||
 |group_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
-| add_index :messages, :body|
 
 ## Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -22,3 +22,51 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|integer|null: false, foreign_key: true|
+|e-mail|integer|null: false, foreign_key: true|
+|password|integer|null: false, foreign_key: true|
+| add_index :users,  :name|
+
+## Association
+- has_many :messages 
+- has_many :groups, through:users_groups
+
+
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group-name|integer|null: false, foreign_key: true|
+
+## Association
+- has_many :users, through:users_groups
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false, foreign_key: true|
+|image|string|null: true, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+| add_index :messages, :body|
+
+## Association
+- belongs_to :group
+- belongs_to :user
+


### PR DESCRIPTION
# What
  chat-spaceのDB構成の設計としてusersテーブル、groupsテーブル、messagesテーブル　中間テーブルのusers-groupsテーブルを記述。

# Why
chat-spaceの構築の事前作業としてDBの設計を行う為。